### PR TITLE
Update migration guide and project files for SDK upgrade from 7.2.0 to o 7.2.1-beta

### DIFF
--- a/migration-guide.md
+++ b/migration-guide.md
@@ -1,68 +1,68 @@
 # DataExchange Connector Migration Guide
-## From 7.1.0 to 7.2.0-beta
+## From 7.2.0 to 7.2.1-beta
 
-### 🔄 Migration Guide: SDK 7.2.0-beta Upgrade
+### 🔄 Migration Guide: SDK 7.2.1-beta Upgrade
 
-This section documents the migration from SDK 7.1.0 to **Autodesk Data Exchange SDK 7.2.0-beta**.
+This section documents the migration from SDK 7.2.0 to **Autodesk Data Exchange SDK 7.2.1-beta**.
 
 ### 📋 Overview of Changes
 
-This is a minor upgrade that includes bug fixes and a small number of API removals:
+This patch upgrade removes the Description field from the Create Exchange form.
 
-- **SDK Version**: Upgraded to `Autodesk.DataExchange 7.2.0-beta`
-- **SDK Version**: Upgraded to `Autodesk.DataExchange.UI 7.2.0-beta`
-- **Bug Fixes**: Various stability and reliability improvements
-- **API Removals**: `SkippedElementType.Miscellaneous` and `SetProgressMessage` have been removed
+- **SDK Version**: Upgraded to `Autodesk.DataExchange 7.2.1-beta`
+- **SDK Version**: Upgraded to `Autodesk.DataExchange.UI 7.2.1-beta`
+- **Bug Fixes**: Description field removed from the Create Exchange form
 
 ### 🚀 Key Dependency Updates
 
 | Package | Previous Version | New Version | Impact |
 |---------|------------------|-------------|---------|
-| `Autodesk.DataExchange` | `7.1.0` | `7.2.0-beta` | **Minor** - Bug fixes and API removals |
-| `Autodesk.DataExchange.UI` | `7.1.0` | `7.2.0-beta` | **Minor** - Bug fixes and API removals |
+| `Autodesk.DataExchange` | `7.2.0` | `7.2.1-beta` | **Patch** - Bug fixes |
+| `Autodesk.DataExchange.UI` | `7.2.0` | `7.2.1-beta` | **Patch** - Bug fixes |
 
 ### ⚠️ Breaking Changes
 
-#### 1. Removal of SkippedElementType.Miscellaneous
+#### 1. Removal of Description field from the Create Exchange form
 
-The `SkippedElementType.Miscellaneous` enum value has been removed from the SDK.
+The `Description` field has been removed from the Create Exchange form UI.
 
-**Before (SDK 7.1.0):**
+**Before (SDK 7.2.0):**
 
-```csharp
-// Using SkippedElementType.Miscellaneous to categorize skipped elements
-element.SkippedElementType = SkippedElementType.Miscellaneous;
+```tsx
+<FormTextField
+  id="create-exchange-description"
+  multiline
+  minRows={1}
+  maxRows={3}
+  title={t("DESCRIPTION")}
+  required={false}
+  variant="outlined"
+  placeholder={t("ADD_DESCRIPTION")}
+  value={description}
+  onChange={(e) => setDescription(e.target.value)}
+/>
 ```
 
-**After (SDK 7.2.0-beta):**
+**After (SDK 7.2.1-beta):**
 
-```csharp
-// SkippedElementType.Miscellaneous is no longer available.
-// Use a more specific SkippedElementType value instead.
-element.SkippedElementType = SkippedElementType.OtherSpecificType;
+```tsx
+// This component is no longer available and usage should be deleted.
+//
+// <FormTextField
+//   id="create-exchange-description"
+//   multiline
+//   minRows={1}
+//   maxRows={3}
+//   title={t("DESCRIPTION")}
+//   required={false}
+//   variant="outlined"
+//   placeholder={t("ADD_DESCRIPTION")}
+//   value={description}
+//   onChange={(e) => setDescription(e.target.value)}
+// />
 ```
 
-**Migration Action:** Search your codebase for any usage of `SkippedElementType.Miscellaneous` and replace it with a more specific `SkippedElementType` value that accurately describes why the element was skipped.
-
-#### 2. Removal of SetProgressMessage
-
-The `SetProgressMessage` method has been removed from the SDK.
-
-**Before (SDK 7.1.0):**
-
-```csharp
-// Setting a progress message during exchange operations
-SetProgressMessage("Processing element...");
-```
-
-**After (SDK 7.2.0-beta):**
-
-```csharp
-// SetProgressMessage is no longer available.
-// Remove all calls to SetProgressMessage from your code.
-```
-
-**Migration Action:** Search your codebase for any calls to `SetProgressMessage` and remove them. If you need to report progress, consult the SDK documentation for alternative approaches available in 7.2.0-beta.
+**Migration Action:** No changes required
 
 ### 🔧 Migration Steps
 
@@ -74,11 +74,11 @@ Update the version numbers in your .csproj file:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Autodesk.DataExchange" Version="7.1.0">
+  <PackageReference Include="Autodesk.DataExchange" Version="7.2.0">
     <IncludeAssets>all</IncludeAssets>
     <ExcludeAssets>runtime; build; native; contentfiles; analyzers</ExcludeAssets>
   </PackageReference>
-  <PackageReference Include="Autodesk.DataExchange.UI" Version="7.1.0" />
+  <PackageReference Include="Autodesk.DataExchange.UI" Version="7.2.0" />
 </ItemGroup>
 ```
 
@@ -86,60 +86,12 @@ Update the version numbers in your .csproj file:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Autodesk.DataExchange" Version="7.2.0-beta">
+  <PackageReference Include="Autodesk.DataExchange" Version="7.2.1-beta">
     <IncludeAssets>all</IncludeAssets>
     <ExcludeAssets>runtime; build; native; contentfiles; analyzers</ExcludeAssets>
   </PackageReference>
-  <PackageReference Include="Autodesk.DataExchange.UI" Version="7.2.0-beta" />
+  <PackageReference Include="Autodesk.DataExchange.UI" Version="7.2.1-beta" />
 </ItemGroup>
-```
-
-#### Step 2: Remove SkippedElementType.Miscellaneous Usage
-
-1. Search your codebase for `SkippedElementType.Miscellaneous`
-2. Replace each occurrence with a more specific `SkippedElementType` value
-
-#### Step 3: Remove SetProgressMessage Calls
-
-1. Search your codebase for `SetProgressMessage`
-2. Remove all calls to this method
-
-#### Step 4: Test Your Changes
-
-1. Build the project and resolve any compilation errors
-2. Run the application and verify all functionality works correctly
-3. Confirm that no references to `SkippedElementType.Miscellaneous` or `SetProgressMessage` remain
-
-### 🎯 Improvements
-
-#### Bug Fixes
-- Various stability and reliability improvements across the SDK
-- See the official release notes for a detailed list of resolved issues
-
-### 🚨 Common Migration Issues
-
-#### 1. **Compilation Error: SkippedElementType.Miscellaneous**
-**Problem:** Compilation fails because `SkippedElementType.Miscellaneous` no longer exists
-```csharp
-// ❌ This will cause a compilation error in 7.2.0-beta
-element.SkippedElementType = SkippedElementType.Miscellaneous;
-```
-**Solution:** Use a more specific `SkippedElementType` value
-```csharp
-// ✅ Use an appropriate specific type
-element.SkippedElementType = SkippedElementType.OtherSpecificType;
-```
-
-#### 2. **Compilation Error: SetProgressMessage**
-**Problem:** Compilation fails because `SetProgressMessage` has been removed
-```csharp
-// ❌ This will cause a compilation error in 7.2.0-beta
-SetProgressMessage("Processing...");
-```
-**Solution:** Remove the call entirely
-```csharp
-// ✅ Simply remove the call
-// (SetProgressMessage is no longer available)
 ```
 
 ### 📚 Additional Resources
@@ -154,4 +106,4 @@ For complex migration scenarios or specific technical questions, consult the off
 
 ---
 
-*This migration guide provides guidance for the transition from version 7.1.0 to 7.2.0-beta. Always refer to the official documentation and release notes for the most accurate and up-to-date information.*
+*This migration guide provides guidance for the transition from version 7.2.0 to 7.2.1-beta. Always refer to the official documentation and release notes for the most accurate and up-to-date information.*

--- a/src/SampleConnector.csproj
+++ b/src/SampleConnector.csproj
@@ -58,8 +58,8 @@
   </PropertyGroup>
   <!-- PackageReference - NuGet will automatically resolve all transitive dependencies -->
   <ItemGroup>
-    <PackageReference Include="Autodesk.DataExchange" Version="7.2.0-beta" />
-    <PackageReference Include="Autodesk.DataExchange.UI" Version="7.2.0-beta" />
+    <PackageReference Include="Autodesk.DataExchange" Version="7.2.1-beta" />
+    <PackageReference Include="Autodesk.DataExchange.UI" Version="7.2.1-beta" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Settings.AppSettings" Version="2.2.2" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />

--- a/test/SampleConnectorUnitTests/SampleConnectorUnitTests.csproj
+++ b/test/SampleConnectorUnitTests/SampleConnectorUnitTests.csproj
@@ -55,8 +55,8 @@
   </PropertyGroup>
   <!-- PackageReference - NuGet will automatically resolve all transitive dependencies -->
   <ItemGroup>
-    <PackageReference Include="Autodesk.DataExchange" Version="7.2.0-beta" />
-    <PackageReference Include="Autodesk.DataExchange.UI" Version="7.2.0-beta" />
+    <PackageReference Include="Autodesk.DataExchange" Version="7.2.1-beta" />
+    <PackageReference Include="Autodesk.DataExchange.UI" Version="7.2.1-beta" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">


### PR DESCRIPTION
### SDK upgrade from 7.2.0-beta to 7.2.1-beta

- `src/SampleConnector.csproj` — Updated Autodesk.DataExchange and Autodesk.DataExchange.UI package references from `7.2.0-beta → 7.2.1-beta`
- `test/SampleConnectorUnitTests/SampleConnectorUnitTests.csproj` — Same package version bump to 7.2.1-beta
migration-guide.md — Updated migration guide for the 7.2.0 → 7.2.1-beta SDK upgrade, including removal of the Description field from the Create Exchange form