### PR TITLE
Upgrade to DXSDK 7.4.0

### DIFF
--- a/src/App.xaml.cs
+++ b/src/App.xaml.cs
@@ -1,7 +1,8 @@
 ﻿using System;
-using System.IO;
-using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Threading;
 using Autodesk.DataExchange;
 
 namespace SampleConnector
@@ -11,12 +12,27 @@ namespace SampleConnector
     /// </summary>
     public partial class App : Application
     {
-        internal static string _installationPath;
+        private const string SingleInstanceMutexName = "Global\\Autodesk.SampleConnector.SingleInstance";
+        private static Mutex singleInstanceMutex;
         private SampleHostWindow hostWindow;
 
         private void Application_Startup(object sender, StartupEventArgs e)
         {
-            // Create and show the main host window
+            singleInstanceMutex = new Mutex(true, SingleInstanceMutexName, out bool createdNew);
+            if (!createdNew)
+            {
+                MessageBox.Show(
+                    "Sample Connector is already running.\n\nClose the existing host window and Connector UI before starting another instance.",
+                    "Sample Connector",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information);
+                this.Shutdown();
+                return;
+            }
+
+            this.DispatcherUnhandledException += this.Application_DispatcherUnhandledException;
+            TaskScheduler.UnobservedTaskException += this.TaskScheduler_UnobservedTaskException;
+
             this.hostWindow = new SampleHostWindow();
             this.hostWindow.Show();
         }
@@ -24,6 +40,23 @@ namespace SampleConnector
         private void Application_Exit(object sender, ExitEventArgs e)
         {
             this.hostWindow?.Destroy();
+            singleInstanceMutex?.ReleaseMutex();
+            singleInstanceMutex?.Dispose();
+        }
+
+        private void Application_DispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
+        {
+            MessageBox.Show(
+                $"An unexpected error occurred:\n\n{e.Exception.Message}",
+                "Sample Connector",
+                MessageBoxButton.OK,
+                MessageBoxImage.Error);
+            e.Handled = true;
+        }
+
+        private void TaskScheduler_UnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
+        {
+            e.SetObserved();
         }
     }
 }

--- a/src/CustomReadWriteModel.cs
+++ b/src/CustomReadWriteModel.cs
@@ -2,6 +2,7 @@ namespace SampleConnector
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
@@ -22,8 +23,10 @@ namespace SampleConnector
         internal IInteropBridge Bridge { get; set; }
 
         private string currentRevision;
+        private string currentExchangeId;
         private ElementDataModel currentElementDataModel;
         private GeometryConfiguration geometryConfiguration;
+        private const int MaxElementsForGeometryPreview = 20;
 
         public CustomReadWriteModel(IClient client) : base(client)
         {
@@ -59,131 +62,198 @@ namespace SampleConnector
         public async Task GetLatestExchangeDataAsync(GetLatestExchangeDetailsEventArgs arg)
         {
             var exchangeItem = arg.ExchangeItem;
-
             var cancellationToken = arg.CancellationToken;
             var progressManager = this.Client.ProgressStepsManager;
             var fetchExchangeStep = progressManager.GetProgressStep(ProgressStepId.FetchExchange);
-            fetchExchangeStep.SubSteps = 2;
+            var downloadExchangeDataStep = progressManager.GetProgressStep(ProgressStepId.DownloadExchangeData);
+
+            fetchExchangeStep.SubSteps = 3;
+
+            var exchangeIdentifier = CreateDataExchangeIdentifier(exchangeItem);
+            this.EnsureExchangeSession(exchangeItem.ExchangeID);
 
             this.Bridge?.SendNotification($"Downloading '{exchangeItem.Name}'", SeverityEnum.Info, 5000);
 
-            var exchangeIdentifier = CreateDataExchangeIdentifier(exchangeItem);
-
             try
             {
-                await this.ProcessExchangeRevisions(exchangeIdentifier, exchangeItem);
+                cancellationToken.ThrowIfCancellationRequested();
 
-                // Logs Skipped Elements
-                this._sDKOptions?.Logger?.LogSkippedElement(SkippedElementType.Failed, "elementId", "Line", "PolyLine");
-                this._sDKOptions?.Logger?.LogSkippedElement(SkippedElementType.Unsupported, "elementId", "Line", "FeatureLine");
-                this._sDKOptions?.Logger?.LogSkippedElement(SkippedElementType.Failed, "elementId");
-                this._sDKOptions?.Logger?.LogSkippedElement(SkippedElementType.Failed, "elementId", "Line", "CurveSet");
+                fetchExchangeStep.UpdateProgress();
+                var revResponse = await this.Client.GetExchangeRevisionsAsync(exchangeIdentifier).ConfigureAwait(false);
+                cancellationToken.ThrowIfCancellationRequested();
 
-                await this.DownloadExchangeGeometry(exchangeIdentifier);
+                fetchExchangeStep.UpdateProgress();
+                var revisions = revResponse.Value;
+                var latestRevisionId = revisions.First().Id;
+                fetchExchangeStep.MarkAsComplete();
+
+                if (!string.IsNullOrEmpty(this.currentRevision) && this.currentRevision == latestRevisionId)
+                {
+                    downloadExchangeDataStep?.MarkAsComplete();
+                    await this.UpdateLocalExchange(exchangeItem).ConfigureAwait(false);
+
+                    var noChangesMessage = $"Exchange '{exchangeItem.Name}' is already up to date.";
+                    this.Bridge?.SendNotification(noChangesMessage, SeverityEnum.Success, 5000);
+                    return;
+                }
+
+                var newerRevisions = new List<string>();
+                var data = await this.GetOrUpdateElementDataAsync(
+                    exchangeIdentifier,
+                    latestRevisionId,
+                    revisions,
+                    newerRevisions,
+                    cancellationToken).ConfigureAwait(false);
+
+                this.LogSkippedElementsSample();
+
+                await this.AnalyzeExchangeElementsAsync(data, newerRevisions, cancellationToken).ConfigureAwait(false);
+                await this.DownloadExchangeGeometryAsync(exchangeIdentifier, downloadExchangeDataStep, cancellationToken).ConfigureAwait(false);
 
                 var successMessage = $"Successfully downloaded '{exchangeItem.Name}'";
                 this.Bridge?.SendNotification(successMessage, SeverityEnum.Success, 0);
 
-                await this.UpdateLocalExchange(exchangeItem);
+                await this.UpdateLocalExchange(exchangeItem).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
             }
             catch (Exception e)
             {
                 var errorMessage = $"Failed to download '{exchangeItem.Name}'";
                 this.Bridge?.SendNotification(errorMessage, SeverityEnum.Error, 0);
-                Console.WriteLine($"{errorMessage}: {e.Message}");
+                this._sDKOptions?.Logger?.Error(e);
+                throw;
             }
         }
 
-        private async Task DownloadExchangeGeometry(DataExchangeIdentifier exchangeIdentifier)
+        private void EnsureExchangeSession(string exchangeId)
         {
-            // Download complete exchange as different formats for demonstration
-            var stepFilePath = this.Client.DownloadCompleteExchangeAsSTEP(exchangeIdentifier);
-            var objFilePath = this.Client.DownloadCompleteExchangeAsOBJ(
-                exchangeIdentifier.ExchangeId,
-                exchangeIdentifier.CollectionId);
-
-            var downloadExchangeDataStep = this.Client.ProgressStepsManager.GetProgressStep(ProgressStepId.DownloadExchangeData);
-            downloadExchangeDataStep?.MarkAsComplete();
-
-            Console.WriteLine($"Downloaded geometry: STEP={stepFilePath}, OBJ={objFilePath}");
+            if (this.currentExchangeId != exchangeId)
+            {
+                this.currentExchangeId = exchangeId;
+                this.currentRevision = null;
+                this.currentElementDataModel = null;
+            }
         }
 
-        private async Task ProcessExchangeRevisions(DataExchangeIdentifier exchangeIdentifier, ExchangeItem exchangeItem)
+        private void LogSkippedElementsSample()
         {
-            var revResponse = await this.Client.GetExchangeRevisionsAsync(exchangeIdentifier);
-            var revisions = revResponse.Value;
-            var latestRevisionId = revisions.First().Id;
-            var newerRevisions = new List<string>();
+            this._sDKOptions?.Logger?.LogSkippedElement(SkippedElementType.Failed, "elementId", "Line", "PolyLine");
+            this._sDKOptions?.Logger?.LogSkippedElement(SkippedElementType.Unsupported, "elementId", "Line", "FeatureLine");
+            this._sDKOptions?.Logger?.LogSkippedElement(SkippedElementType.Failed, "elementId");
+            this._sDKOptions?.Logger?.LogSkippedElement(SkippedElementType.Failed, "elementId", "Line", "CurveSet");
+        }
 
-            if (!string.IsNullOrEmpty(this.currentRevision) && this.currentRevision == latestRevisionId)
+        private async Task DownloadExchangeGeometryAsync(
+            DataExchangeIdentifier exchangeIdentifier,
+            Autodesk.DataExchange.ProgressManager.Interfaces.IProgressStep downloadExchangeDataStep,
+            CancellationToken cancellationToken)
+        {
+            var downloadPath = Path.Combine(
+                Path.GetTempPath(),
+                "SampleConnector",
+                exchangeIdentifier.ExchangeId);
+
+            Directory.CreateDirectory(downloadPath);
+
+            await Task.Run(
+                () =>
+                {
+                    var stepResult = this.Client.DownloadCompleteExchangeAsSTEP(exchangeIdentifier, downloadPath, cancellationToken);
+                    if (stepResult.IsFailed)
+                    {
+                        this._sDKOptions?.Logger?.Error($"STEP download failed: {string.Join(", ", stepResult.Errors)}");
+                    }
+                    else
+                    {
+                        this._sDKOptions?.Logger?.Information($"STEP downloaded to: {stepResult.Value}");
+                    }
+
+                    var objResult = this.Client.DownloadCompleteExchangeAsOBJ(
+                        exchangeIdentifier.ExchangeId,
+                        exchangeIdentifier.CollectionId,
+                        downloadPath,
+                        cancellationToken);
+
+                    if (objResult.IsFailed)
+                    {
+                        this._sDKOptions?.Logger?.Error($"OBJ download failed: {string.Join(", ", objResult.Errors)}");
+                    }
+                    else
+                    {
+                        this._sDKOptions?.Logger?.Information($"OBJ downloaded to: {objResult.Value}");
+                    }
+                },
+                cancellationToken).ConfigureAwait(false);
+
+            downloadExchangeDataStep?.MarkAsComplete();
+        }
+
+        private async Task AnalyzeExchangeElementsAsync(
+            ElementDataModel data,
+            List<string> newerRevisions,
+            CancellationToken cancellationToken)
+        {
+            if (data == null)
             {
-                Console.WriteLine("No changes found");
                 return;
             }
 
-            // Update progress for FetchExchange step
-            var fetchExchangeStep = this.Client.ProgressStepsManager.GetProgressStep(ProgressStepId.FetchExchange);
-            fetchExchangeStep?.UpdateProgress();
-
-            ElementDataModel data = await this.GetOrUpdateElementData(exchangeIdentifier, latestRevisionId, revisions, newerRevisions);
-            fetchExchangeStep?.MarkAsComplete();
-
-            await this.AnalyzeExchangeElements(data, newerRevisions);
-        }
-
-        private async Task AnalyzeExchangeElements(ElementDataModel data, List<string> newerRevisions)
-        {
-            // Demonstrate various element analysis operations
             var wallElements = data.Elements.Where(element => element.Category == "Walls").ToList();
             var addedElements = data.GetCreatedElements(newerRevisions);
             var modifiedElements = data.GetModifiedElements(newerRevisions);
             var deletedElements = data.GetDeletedElements(newerRevisions);
 
-            // Load geometry for all elements
-            var geometries = await data.GetElementGeometriesAsync(data.Elements);
+            var elementList = data.Elements.ToList();
+            if (elementList.Count > 0 && elementList.Count <= MaxElementsForGeometryPreview)
+            {
+                await data.GetElementGeometriesAsync(elementList, cancellationToken).ConfigureAwait(false);
+            }
 
-            // Log analysis results for sample purposes
-            Console.WriteLine($"Analysis: {wallElements.Count} walls, {addedElements.Count()} added, " +
-                            $"{modifiedElements.Count()} modified, {deletedElements.Count()} deleted elements");
+            Console.WriteLine(
+                $"Analysis: {wallElements.Count} walls, {addedElements.Count()} added, " +
+                $"{modifiedElements.Count()} modified, {deletedElements.Count()} deleted elements");
         }
 
-        private async Task<ElementDataModel> GetOrUpdateElementData(
+        private async Task<ElementDataModel> GetOrUpdateElementDataAsync(
             DataExchangeIdentifier exchangeIdentifier,
             string latestRevisionId,
             IEnumerable<ExchangeRevision> revisions,
-            List<string> newerRevisions)
+            List<string> newerRevisions,
+            CancellationToken cancellationToken)
         {
-            ElementDataModel data;
+            cancellationToken.ThrowIfCancellationRequested();
 
             if (this.currentElementDataModel == null)
             {
-                // Get full exchange data for the first time
-                var response = await this.Client.GetElementDataModelAsync(exchangeIdentifier);
+                var response = await this.Client.GetElementDataModelAsync(exchangeIdentifier).ConfigureAwait(false);
                 this.currentElementDataModel = response.Value;
                 this.currentRevision = latestRevisionId;
-                data = this.currentElementDataModel;
                 newerRevisions.Add(latestRevisionId);
+                return this.currentElementDataModel;
             }
-            else
-            {
-                // Update with delta changes
-                var response = await this.Client.RetrieveLatestExchangeDataAsync(this.currentElementDataModel);
-                var newRevision = response.Value;
 
-                if (!string.IsNullOrEmpty(newRevision))
+            var deltaResponse = await this.Client.RetrieveLatestExchangeDataAsync(this.currentElementDataModel).ConfigureAwait(false);
+            var newRevision = deltaResponse.Value;
+
+            if (!string.IsNullOrEmpty(newRevision))
+            {
+                foreach (var revision in revisions)
                 {
-                    foreach (var revision in revisions)
+                    if (revision.Id == this.currentRevision)
                     {
-                        if (revision.Id == this.currentRevision) break;
-                        newerRevisions.Add(revision.Id);
+                        break;
                     }
-                    this.currentRevision = newRevision;
+
+                    newerRevisions.Add(revision.Id);
                 }
 
-                data = ElementDataModel.Create(Client);
+                this.currentRevision = newRevision;
             }
 
-            return data;
+            return this.currentElementDataModel;
         }
 
 
@@ -265,16 +335,16 @@ namespace SampleConnector
             }
         }
 
-        [Obsolete]
         private async Task GenerateViewableAsync(ExchangeItem exchangeItem)
         {
             await Task.Run(async () =>
             {
                 try
                 {
-                    // Simulate processing time - in real scenario this would be determined by the actual process
-                    await Task.Delay(ViewableGenerationDelayMs);
-                    await this.Client.GenerateViewableAsync(exchangeItem.ExchangeID, exchangeItem.ContainerID);
+                    await Task.Delay(ViewableGenerationDelayMs).ConfigureAwait(false);
+#pragma warning disable CS0618
+                    await this.Client.GenerateViewableAsync(exchangeItem.ExchangeID, exchangeItem.ContainerID).ConfigureAwait(false);
+#pragma warning restore CS0618
                 }
                 catch (Exception ex)
                 {
@@ -363,28 +433,31 @@ namespace SampleConnector
 
         private async Task UpdateLocalExchange(ExchangeItem exchangeItem)
         {
-            var dataExchangeIdentifier = new DataExchangeIdentifier
-            {
-                CollectionId = exchangeItem.ContainerID,
-                ExchangeId = exchangeItem.ExchangeID,
-                HubId = exchangeItem.HubId,
-            };
+            var loadExchangeStep = this.Client.ProgressStepsManager.GetProgressStep(ProgressStepId.LoadExchange);
+            var dataExchangeIdentifier = CreateDataExchangeIdentifier(exchangeItem);
 
-            DataExchange exchange = await base.GetExchangeAsync(dataExchangeIdentifier);
+            DataExchange exchange = await base.GetExchangeAsync(dataExchangeIdentifier).ConfigureAwait(false);
             if (exchange != null)
             {
                 exchangeItem.FileVersion = exchange.FileVersionId;
                 exchangeItem.LastModified = exchange.Updated;
             }
 
-            var localExchange = localStorage.FirstOrDefault(item => item.ExchangeID == exchange.ExchangeID);
-            if (localExchange != null)
+            var localExchange = this.localStorage.FirstOrDefault(item => item.ExchangeID == exchange?.ExchangeID);
+            if (localExchange != null && exchange != null)
             {
                 if (localExchange.FileVersionId != exchange.FileVersionId)
+                {
                     localExchange.FileVersionId = exchange.FileVersionId;
+                }
+
                 if (localExchange.Updated != exchange.Updated)
+                {
                     localExchange.Updated = exchange.Updated;
+                }
             }
+
+            loadExchangeStep?.MarkAsComplete();
         }
 
         public List<DataExchange> GetLocalExchanges()

--- a/src/MainThreadInvoker.cs
+++ b/src/MainThreadInvoker.cs
@@ -18,11 +18,11 @@ namespace SampleConnector
         {
             if (this.dispatcher.CheckAccess())
             {
-                return await func();
+                return await func().ConfigureAwait(true);
             }
 
             var operation = await this.dispatcher.InvokeAsync(func);
-            return await operation;
+            return await operation.ConfigureAwait(true);
         }
     }
 }

--- a/src/SampleConnector.csproj
+++ b/src/SampleConnector.csproj
@@ -58,8 +58,9 @@
   </PropertyGroup>
   <!-- PackageReference - NuGet will automatically resolve all transitive dependencies -->
   <ItemGroup>
-    <PackageReference Include="Autodesk.DataExchange" Version="7.2.1-beta" />
-    <PackageReference Include="Autodesk.DataExchange.UI" Version="7.2.1-beta" />
+    <PackageReference Include="Autodesk.DataExchange" Version="7.4.0-beta" />
+    <PackageReference Include="Autodesk.DataExchange.UI" Version="7.4.0-beta" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Settings.AppSettings" Version="2.2.2" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />

--- a/src/SampleHostWindow.xaml
+++ b/src/SampleHostWindow.xaml
@@ -5,21 +5,25 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:SampleConnector"
         mc:Ignorable="d"
-        Title="Sample Host Window" Height="400" Width="640" ResizeMode="NoResize">
-    <Grid>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="12.5*"/>
-            <ColumnDefinition Width="75*"/>
-            <ColumnDefinition Width="12.5*"/>
-        </Grid.ColumnDefinitions>
-        
-        <TextBlock Grid.Column="1"
-                   Text="This is the main window of your host application. It is essential for the proper functioning of the Connector UI, which depends on it for operations like window message handling and ownership management. The main window also determines the Connector UI's lifetime -- closing it will automatically close the Connector UI as well."
-                   HorizontalAlignment="Center"
-                   VerticalAlignment="Center"
+        Title="Sample Host App (keep open)" Height="420" Width="700" ResizeMode="NoResize" Topmost="False" ShowInTaskbar="True">
+    <Grid Margin="20">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock x:Name="StatusText"
+                   Grid.Row="0"
+                   Text="Starting connector..."
+                   FontSize="16"
+                   FontWeight="SemiBold"
                    TextWrapping="Wrap"
-                   TextAlignment="Center"
-                   FontSize="14"
-                   Margin="20"/>
+                   Margin="0,0,0,16"/>
+
+        <TextBlock Grid.Row="1"
+                   Text="This is the host application window. The Connector UI runs in a separate window but must stay connected to this process. Do not close this window while using Data Exchange — closing it causes the &quot;Connection Lost&quot; error in the Connector UI."
+                   TextWrapping="Wrap"
+                   TextAlignment="Left"
+                   FontSize="14"/>
     </Grid>
 </Window>

--- a/src/SampleHostWindow.xaml.cs
+++ b/src/SampleHostWindow.xaml.cs
@@ -23,16 +23,71 @@ namespace SampleConnector
         private CustomReadWriteModel customReadWriteModel;
         private SDKOptionsDefaultSetup sdkOptions;
         private IClient client;
+        private bool connectorInitialized;
+        private bool isDestroying;
 
         public SampleHostWindow()
         {
             this.InitializeComponent();
             this.RegisterSystemLanguage();
-            this.InitializeConnector();
+            this.Loaded += this.OnWindowLoaded;
+            this.Closed += (_, __) => this.Destroy();
+        }
+
+        private async void OnWindowLoaded(object sender, RoutedEventArgs e)
+        {
+            this.Loaded -= this.OnWindowLoaded;
+
+            if (this.connectorInitialized)
+            {
+                return;
+            }
+
+            var windowHelper = new WindowInteropHelper(this);
+            windowHelper.EnsureHandle();
+
+            if (windowHelper.Handle == IntPtr.Zero)
+            {
+                MessageBox.Show(
+                    this,
+                    "Failed to obtain the host window handle. The Connector UI cannot connect to this application.",
+                    "Sample Connector",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error);
+                return;
+            }
+
+            try
+            {
+                this.StatusText.Text = "Initializing connector (authenticating)...";
+                await this.InitializeConnectorAsync(windowHelper.Handle).ConfigureAwait(true);
+                this.connectorInitialized = true;
+                this.StatusText.Text = "Connector is running. Keep this window open while using the Connector UI.";
+                this.Activate();
+                this.Focus();
+            }
+            catch (Exception ex)
+            {
+                this.sdkOptions?.Logger?.Error(ex);
+                MessageBox.Show(
+                    this,
+                    $"Failed to start the Data Exchange Connector:\n\n{ex.Message}",
+                    "Sample Connector",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error);
+                this.StatusText.Text = "Connector failed to start. See the error dialog for details.";
+            }
         }
 
         public void Destroy()
         {
+            if (this.isDestroying)
+            {
+                return;
+            }
+
+            this.isDestroying = true;
+
             if (this.customReadWriteModel != null)
             {
                 var exchanges = this.customReadWriteModel.GetLocalExchanges();
@@ -43,7 +98,6 @@ namespace SampleConnector
 
                 this.sdkOptions?.Storage.Save();
 
-                // Destroy interop bridge object and Connector UI
                 if (this.customReadWriteModel.Bridge != null)
                 {
                     this.customReadWriteModel.Bridge.SetWindowState(WindowStateEnum.Close);
@@ -64,9 +118,8 @@ namespace SampleConnector
                     XmlLanguage.GetLanguage(CultureInfo.CurrentCulture.IetfLanguageTag)));
         }
 
-        private void InitializeConnector()
+        private async Task InitializeConnectorAsync(IntPtr hostWindowHandle)
         {
-            // Read configuration
             var authClientId = ConfigurationManager.AppSettings["AuthClientId"];
             var authClientSecret = ConfigurationManager.AppSettings["AuthClientSecret"];
             var authCallback = ConfigurationManager.AppSettings["AuthCallback"];
@@ -76,7 +129,6 @@ namespace SampleConnector
             var hostApplicationName = ConfigurationManager.AppSettings["HostApplicationName"];
             var hostApplicationVersion = ConfigurationManager.AppSettings["HostApplicationVersion"];
 
-            // Validate required configuration
             if (string.IsNullOrEmpty(authClientId))
             {
                 throw new ConfigurationErrorsException("AuthClientId is missing from App.config. Please ensure the config file is properly configured.");
@@ -98,75 +150,58 @@ namespace SampleConnector
                 throw new ConfigurationErrorsException("ConnectorName, ConnectorVersion, HostApplicationName, and HostApplicationVersion are required in App.config.");
             }
 
-            // Step 1: Create SDK options (using PKCE auth flow - no client secret needed)
             this.sdkOptions = new SDKOptionsDefaultSetup()
             {
                 CallBack = authCallback,
                 ClientId = authClientId,
+                ClientSecret = authClientSecret,
                 ConnectorName = connectorName,
                 ConnectorVersion = connectorVersion,
                 HostApplicationName = hostApplicationName,
                 HostApplicationVersion = hostApplicationVersion,
             };
 
-            // Step 2: Create the Client (this triggers authentication)
-            this.client = new Client(this.sdkOptions);
+            // Create the client off the UI thread so OAuth does not block message handling.
+            await Task.Run(() =>
+            {
+                this.client = new Client(this.sdkOptions);
+            }).ConfigureAwait(true);
 
-            // Configure logging
             if (this.GetLogLevel(logLevel) == LogLevel.Debug)
             {
                 this.SetDebugLogLevel(this.sdkOptions?.Logger);
             }
 
-            // Step 3: Create the exchange model with the client
-            this.customReadWriteModel = new CustomReadWriteModel(this.client);
+            // Finish authentication before the Connector UI connects and requests a token.
+            await this.sdkOptions.AuthProvider.GetAuthTokenAsync().ConfigureAwait(true);
 
-            // Load locally cached exchanges
+            this.customReadWriteModel = new CustomReadWriteModel(this.client);
             this.LoadLocalExchanges();
 
-            // Step 4: Create InteropBridgeOptions from the client
             var bridgeOptions = InteropBridgeOptions.FromClient(this.client);
             bridgeOptions.Exchange = this.customReadWriteModel;
             bridgeOptions.Invoker = new MainThreadInvoker(this.Dispatcher);
             bridgeOptions.FeedbackUrl = "https://some.feedback.url";
-            bridgeOptions.HostWindowHandle = new WindowInteropHelper(this).Handle;
+            bridgeOptions.HostWindowHandle = hostWindowHandle;
 
-            // Step 5: Create the bridge and assign it to the model
             var bridge = InteropBridgeFactory.Create(bridgeOptions);
             this.customReadWriteModel.Bridge = bridge;
 
-            // Subscribe to ClientStateChanged event for UI state notifications
             bridge.ClientStateChanged += (sender, e) =>
             {
                 if (e.IsConnected)
                 {
-                    // Set the document name only after the Connector UI is connected.
-                    // If SetDocumentName is called too early, it will have no effect
-                    // because the Connector UI does not yet exist at that point.
                     this.customReadWriteModel.Bridge.SetDocumentName("Sample Document");
                 }
             };
 
-            // Initialize and launch the connector UI asynchronously
-            _ = this.InitializeAndLaunchConnectorUi(bridge);
+            await this.InitializeAndLaunchConnectorUiAsync(bridge).ConfigureAwait(true);
         }
 
-        private async Task InitializeAndLaunchConnectorUi(IInteropBridge interopBridge)
+        private async Task InitializeAndLaunchConnectorUiAsync(IInteropBridge interopBridge)
         {
-            try
-            {
-                // Initialize the interop bridge first
-                await interopBridge.InitializeAsync();
-
-                // Then launch the connector UI
-                await interopBridge.LaunchConnectorUiAsync();
-            }
-            catch (Exception ex)
-            {
-                // Log errors during initialization/launching
-                this.sdkOptions?.Logger?.Error(ex);
-                throw;
-            }
+            await interopBridge.InitializeAsync().ConfigureAwait(true);
+            await interopBridge.LaunchConnectorUiAsync().ConfigureAwait(true);
         }
 
         private LogLevel GetLogLevel(string logLevel)
@@ -179,11 +214,6 @@ namespace SampleConnector
         private void SetDebugLogLevel(ILogger logger)
         {
             logger?.SetDebugLogLevel();
-        }
-
-        private void EnableHttpLogsForDebugging()
-        {
-            (this.client as Client)?.EnableHttpDebugLogging();
         }
 
         private void LoadLocalExchanges()

--- a/test/SampleConnectorUnitTests/SampleConnectorUnitTests.csproj
+++ b/test/SampleConnectorUnitTests/SampleConnectorUnitTests.csproj
@@ -55,8 +55,8 @@
   </PropertyGroup>
   <!-- PackageReference - NuGet will automatically resolve all transitive dependencies -->
   <ItemGroup>
-    <PackageReference Include="Autodesk.DataExchange" Version="7.2.1-beta" />
-    <PackageReference Include="Autodesk.DataExchange.UI" Version="7.2.1-beta" />
+    <PackageReference Include="Autodesk.DataExchange" Version="7.4.0-beta" />
+    <PackageReference Include="Autodesk.DataExchange.UI" Version="7.4.0-beta" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">


### PR DESCRIPTION
Upgrade to DXSDK 7.4.0
**Overview**
This PR upgrades Autodesk.DataExchange and Autodesk.DataExchange.UI from 7.2.1-beta to 7.4.0-beta. Beyond the package bump it contains several meaningful behavioral and robustness improvements across the connector lifecycle.

**What Changed**
[App.xaml.cs](vscode-webview://0au6h35v59615tl2ac1b6am5nsj4514k3amcgk3a20c3ks32hj60/src/App.xaml.cs)

- Added single-instance enforcement via a named Global\\ Mutex — prevents two copies running simultaneously.

- Added global unhandled-exception handlers (DispatcherUnhandledException, TaskScheduler.UnobservedTaskException).

[SampleHostWindow.xaml.cs](vscode-webview://0au6h35v59615tl2ac1b6am5nsj4514k3amcgk3a20c3ks32hj60/src/SampleHostWindow.xaml.cs)

- Deferred InitializeConnector to Window.Loaded so a real HWND exists before the bridge is created — this directly fixes the "Connection Lost" bug.

- Moved OAuth/client construction off the UI thread with Task.Run.

- Pre-warms auth token (GetAuthTokenAsync) before the Connector UI connects.

- Added isDestroying guard to prevent double-dispose.

[CustomReadWriteModel.cs](vscode-webview://0au6h35v59615tl2ac1b6am5nsj4514k3amcgk3a20c3ks32hj60/src/CustomReadWriteModel.cs)

- Propagated CancellationToken throughout the download pipeline.

- Added proper result checking for STEP/OBJ downloads (was previously fire-and-forget with Console.WriteLine).

- Added EnsureExchangeSession to reset cached state on exchange switch.

- Geometry downloads now run on Task.Run (off UI thread) with result structured as IsFailed/Value.

- Fixed a subtle delta-path bug: previously returned ElementDataModel.Create(Client) (empty model) for the delta case — now correctly returns this.currentElementDataModel.

[SampleHostWindow.xaml](vscode-webview://0au6h35v59615tl2ac1b6am5nsj4514k3amcgk3a20c3ks32hj60/src/SampleHostWindow.xaml)

- UI copy updated to clarify that closing the host window breaks the Connector UI.

- Added StatusText label that shows real-time init progress.