### PR TITLE
Upgrade sample to DXSDK 7.5.0-beta

### DIFF
--- a/src/CreateExchangeHelper.cs
+++ b/src/CreateExchangeHelper.cs
@@ -1,8 +1,8 @@
 using Autodesk.DataExchange.Core.Enums;
 using Autodesk.DataExchange.DataModels;
 using Autodesk.DataExchange.SchemaObjects.Units;
-using Autodesk.GeometryPrimitives.Data;
-using Autodesk.GeometryPrimitives.Data.DX;
+using Autodesk.GeometryUtilities.PrimitivesAPI;
+using Autodesk.GeometryUtilities.PrimitivesAPI.DX;
 using Autodesk.GeometryUtilities.MeshAPI;
 using Autodesk.Parameters;
 using System;

--- a/src/CustomReadWriteModel.cs
+++ b/src/CustomReadWriteModel.cs
@@ -35,7 +35,6 @@ namespace SampleConnector
         }
 
         private List<DataExchange> localStorage = new List<DataExchange>();
-        private const int ViewableGenerationDelayMs = 5000;
 
         public override async Task<List<DataExchange>> GetExchangesAsync(ExchangeSearchFilter exchangeSearchFilter)
         {
@@ -299,7 +298,8 @@ namespace SampleConnector
 
                 await this.Client.SyncExchangeDataAsync(dataExchangeIdentifier, elementDataModel);
 
-                await this.GenerateViewableAsync(exchangeItem);
+                // Viewable generation is handled server-side in SDK 7.5.0; the client-side
+                // Client.GenerateViewableAsync API was removed (no replacement).
             }
             catch (Exception e)
             {
@@ -333,25 +333,6 @@ namespace SampleConnector
             {
                 return await this.UpdateExistingExchangeData();
             }
-        }
-
-        private async Task GenerateViewableAsync(ExchangeItem exchangeItem)
-        {
-            await Task.Run(async () =>
-            {
-                try
-                {
-                    await Task.Delay(ViewableGenerationDelayMs).ConfigureAwait(false);
-#pragma warning disable CS0618
-                    await this.Client.GenerateViewableAsync(exchangeItem.ExchangeID, exchangeItem.ContainerID).ConfigureAwait(false);
-#pragma warning restore CS0618
-                }
-                catch (Exception ex)
-                {
-                    this._sDKOptions?.Logger?.Error(ex);
-                    throw;
-                }
-            });
         }
 
         private void HandleUpdateError(Exception exception, string exchangeName)

--- a/src/SampleConnector.csproj
+++ b/src/SampleConnector.csproj
@@ -58,8 +58,8 @@
   </PropertyGroup>
   <!-- PackageReference - NuGet will automatically resolve all transitive dependencies -->
   <ItemGroup>
-    <PackageReference Include="Autodesk.DataExchange" Version="7.4.0-beta" />
-    <PackageReference Include="Autodesk.DataExchange.UI" Version="7.4.0-beta" />
+    <PackageReference Include="Autodesk.DataExchange" Version="7.5.0-alpha.3" />
+    <PackageReference Include="Autodesk.DataExchange.UI" Version="7.5.0-alpha.3" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Settings.AppSettings" Version="2.2.2" />

--- a/src/SampleConnector.csproj
+++ b/src/SampleConnector.csproj
@@ -58,7 +58,7 @@
   </PropertyGroup>
   <!-- PackageReference - NuGet will automatically resolve all transitive dependencies -->
   <ItemGroup>
-    <PackageReference Include="Autodesk.DataExchange" Version="7.5.0-alpha.3" />
+    <PackageReference Include="Autodesk.DataExchange" Version="7.5.0-beta" />
     <PackageReference Include="Autodesk.DataExchange.UI" Version="7.5.0-alpha.3" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />

--- a/test/SampleConnectorUnitTests/SampleConnectorUnitTests.csproj
+++ b/test/SampleConnectorUnitTests/SampleConnectorUnitTests.csproj
@@ -55,8 +55,8 @@
   </PropertyGroup>
   <!-- PackageReference - NuGet will automatically resolve all transitive dependencies -->
   <ItemGroup>
-    <PackageReference Include="Autodesk.DataExchange" Version="7.4.0-beta" />
-    <PackageReference Include="Autodesk.DataExchange.UI" Version="7.4.0-beta" />
+    <PackageReference Include="Autodesk.DataExchange" Version="7.5.0-alpha.3" />
+    <PackageReference Include="Autodesk.DataExchange.UI" Version="7.5.0-alpha.3" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/test/SampleConnectorUnitTests/SampleConnectorUnitTests.csproj
+++ b/test/SampleConnectorUnitTests/SampleConnectorUnitTests.csproj
@@ -55,7 +55,7 @@
   </PropertyGroup>
   <!-- PackageReference - NuGet will automatically resolve all transitive dependencies -->
   <ItemGroup>
-    <PackageReference Include="Autodesk.DataExchange" Version="7.5.0-alpha.3" />
+    <PackageReference Include="Autodesk.DataExchange" Version="7.5.0-beta" />
     <PackageReference Include="Autodesk.DataExchange.UI" Version="7.5.0-alpha.3" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />


### PR DESCRIPTION
- Bump Autodesk.DataExchange/.UI 7.4.0-beta -> 7.5.0-alpha.3 (src + tests).
- Migrate Autodesk.GeometryPrimitives.Data[.DX] -> Autodesk.GeometryUtilities.PrimitivesAPI[.DX].
- Remove obsolete client-side Client.GenerateViewableAsync call (removed in 7.5.0; viewable generation is now handled server-side).