### PR TITLE
Update the migration Guide

### DIFF
--- a/migration-guide.md
+++ b/migration-guide.md
@@ -15,7 +15,7 @@ This section documents the migration from SDK 7.2.1-beta to **Autodesk Data Exch
 ### 📋 Overview of Changes
 
 - **SDK Version**: Upgraded to `Autodesk.DataExchange 7.5.0-beta`
-- **UI SDK Version**: Upgraded to `Autodesk.DataExchange.UI 7.5.0-alpha.3`
+- **UI SDK Version**: Upgraded to `Autodesk.DataExchange.UI 7.5.0-beta`
 - **Breaking Changes**: Yes — see below
 - **Build result**: 0 errors after fixes applied
 
@@ -24,7 +24,7 @@ This section documents the migration from SDK 7.2.1-beta to **Autodesk Data Exch
 | Package | Previous Version | New Version | Impact |
 |---------|------------------|-------------|---------|
 | `Autodesk.DataExchange` | `7.2.1-beta` | `7.5.0-beta` | **Minor** - breaking changes |
-| `Autodesk.DataExchange.UI` | `7.2.1-beta` | `7.5.0-alpha.3` | **Minor** - breaking changes |
+| `Autodesk.DataExchange.UI` | `7.2.1-beta` | `7.5.0-beta` | **Minor** - breaking changes |
 
 ### ⚠️ Breaking Changes
 
@@ -132,7 +132,7 @@ longer required (NuGet resolves transitive dependencies automatically):
 ```xml
 <ItemGroup>
   <PackageReference Include="Autodesk.DataExchange" Version="7.5.0-beta" />
-  <PackageReference Include="Autodesk.DataExchange.UI" Version="7.5.0-alpha.3" />
+  <PackageReference Include="Autodesk.DataExchange.UI" Version="7.5.0-beta" />
 </ItemGroup>
 ```
 

--- a/migration-guide.md
+++ b/migration-guide.md
@@ -1,7 +1,200 @@
-# DataExchange Connector Migration Guide
-## From 7.2.0 to 7.2.1-beta
+# DataExchange Connector UI Migration Guide
 
-### 🔄 Migration Guide: SDK 7.2.1-beta Upgrade
+This guide documents SDK upgrades for the **Sample UI Connector**. The most recent
+migration is listed first; earlier migrations are preserved below for reference.
+
+- [🔄 Migration Guide: SDK 7.5.0 Upgrade](#-migration-guide-sdk-750-upgrade) — **latest**
+- [🔄 Migration Guide: SDK 7.2.1-beta Upgrade](#-migration-guide-sdk-721-beta-upgrade)
+
+---
+
+## 🔄 Migration Guide: SDK 7.5.0 Upgrade
+
+This section documents the migration from SDK 7.2.1-beta to **Autodesk Data Exchange SDK 7.5.0**.
+
+### 📋 Overview of Changes
+
+- **SDK Version**: Upgraded to `Autodesk.DataExchange 7.5.0-beta`
+- **UI SDK Version**: Upgraded to `Autodesk.DataExchange.UI 7.5.0-alpha.3`
+- **Breaking Changes**: Yes — see below
+- **Build result**: 0 errors after fixes applied
+
+### 🚀 Key Dependency Updates
+
+| Package | Previous Version | New Version | Impact |
+|---------|------------------|-------------|---------|
+| `Autodesk.DataExchange` | `7.2.1-beta` | `7.5.0-beta` | **Minor** - breaking changes |
+| `Autodesk.DataExchange.UI` | `7.2.1-beta` | `7.5.0-alpha.3` | **Minor** - breaking changes |
+
+### ⚠️ Breaking Changes
+
+#### 1. `Client.GenerateViewableAsync` removed — viewable generation is now server-side
+
+In SDK 7.5.0 viewable generation is handled **server-side**. The client-side
+`Client.GenerateViewableAsync` API was removed with **no replacement** — after
+`SyncExchangeDataAsync` completes, the service generates the viewable automatically.
+
+**Before (7.2.1):**
+
+```csharp
+await this.Client.SyncExchangeDataAsync(dataExchangeIdentifier, elementDataModel);
+
+// Explicitly request viewable generation from the client.
+await this.Client.GenerateViewableAsync(exchangeItem.ExchangeID, dataExchangeIdentifier.CollectionId);
+```
+
+**After (7.5.0):**
+
+```csharp
+await this.Client.SyncExchangeDataAsync(dataExchangeIdentifier, elementDataModel);
+
+// Viewable generation is handled server-side in SDK 7.5.0; the client-side
+// Client.GenerateViewableAsync API was removed (no replacement).
+```
+
+**Migration Action:** Remove all calls to `Client.GenerateViewableAsync`.
+
+#### 2. `RenderStyle` and `RGBA` default constructors deprecated
+
+The parameterless constructors with property setters are marked `[Obsolete]`. Use the
+parameterized constructors instead.
+
+**Before (7.2.1):**
+
+```csharp
+private RenderStyle commonRenderStyle = new RenderStyle()
+{
+    Name = "Common Render Style",
+    RGBA = new RGBA() { Red = 255, Green = 0, Blue = 0, Alpha = 255 },
+    Transparency = 1
+};
+```
+
+**After (7.5.0):**
+
+```csharp
+private RenderStyle commonRenderStyle = new RenderStyle("Common Render Style", new RGBA(255, 0, 0, 255), 1);
+```
+
+**Migration Action:** Replace every `new RenderStyle() { ... }` / `new RGBA() { ... }`
+with the parameterized form `new RenderStyle(name, rgba, transparency)` /
+`new RGBA(red, green, blue, alpha)`.
+
+#### 3. Complete authentication before launching the Connector UI
+
+The `Client` constructor calls `Initialize()` internally, and the Connector UI
+requests a token as soon as it connects. Create the `Client` **off the UI thread**
+and finish authentication (`GetAuthTokenAsync`) **before** wiring up and launching
+the `IInteropBridge`, so the UI does not race the auth flow.
+
+**After (7.5.0):**
+
+```csharp
+// Create the client off the UI thread so OAuth does not block message handling.
+await Task.Run(() =>
+{
+    this.client = new Client(this.sdkOptions);
+}).ConfigureAwait(true);
+
+// Finish authentication before the Connector UI connects and requests a token.
+await this.sdkOptions.AuthProvider.GetAuthTokenAsync().ConfigureAwait(true);
+
+// Now build the bridge and launch the UI.
+var bridgeOptions = InteropBridgeOptions.FromClient(this.client);
+// ...
+```
+
+**Migration Action:** Move client creation onto a background thread and call
+`GetAuthTokenAsync()` before creating/launching the `IInteropBridge`.
+
+### 🔧 Migration Steps
+
+#### Step 1: Update Package References
+
+Update the version numbers in `src/SampleConnector.csproj`. The `PackageReference`
+format is also simplified — the `IncludeAssets`/`ExcludeAssets` overrides are no
+longer required (NuGet resolves transitive dependencies automatically):
+
+**Before:**
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Autodesk.DataExchange" Version="7.2.1-beta">
+    <IncludeAssets>all</IncludeAssets>
+    <ExcludeAssets>runtime; build; native; contentfiles; analyzers</ExcludeAssets>
+  </PackageReference>
+  <PackageReference Include="Autodesk.DataExchange.UI" Version="7.2.1-beta" />
+</ItemGroup>
+```
+
+**After:**
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Autodesk.DataExchange" Version="7.5.0-beta" />
+  <PackageReference Include="Autodesk.DataExchange.UI" Version="7.5.0-alpha.3" />
+</ItemGroup>
+```
+
+Apply the same version updates to `test/SampleConnectorUnitTests/SampleConnectorUnitTests.csproj`.
+
+#### Step 2: Apply the Code Fixes
+
+1. **`CustomReadWriteModel.cs`** — remove the `Client.GenerateViewableAsync` call after `SyncExchangeDataAsync`.
+2. **`CreateExchangeHelper.cs`** — replace `new RenderStyle() { ... }` / `new RGBA() { ... }` with the parameterized constructors.
+3. **`SampleHostWindow.xaml.cs`** — create the `Client` off the UI thread and call `GetAuthTokenAsync()` before launching the Connector UI.
+
+#### Step 3: Restore and Rebuild
+
+**Visual Studio:**
+- Open `src/SampleConnector.sln`
+- Rebuild the solution (packages restore automatically)
+
+**Command Line:**
+
+```bash
+BuildSolution.bat
+```
+
+### 🎯 Summary of Changes
+
+| Aspect | SDK 7.2.1 | SDK 7.5.0 |
+|--------|-----------|-----------|
+| Viewable generation | Client-side via `GenerateViewableAsync` | Server-side; API removed |
+| `RenderStyle` / `RGBA` | Default constructor + setters | Parameterized constructors required |
+| Auth flow | Token fetched lazily | Call `GetAuthTokenAsync()` before launching the UI |
+| Client construction | On UI thread | Off the UI thread (`Task.Run`) |
+| `PackageReference` | `IncludeAssets`/`ExcludeAssets` overrides | Simplified — no asset overrides |
+
+### 🧪 Testing Your Migration
+
+After upgrading, launch the sample and confirm:
+
+- ✅ OAuth2 sign-in completes before the Connector UI appears
+- ✅ Create Exchange publishes successfully (all geometry types)
+- ✅ Update Exchange adds a new revision without errors
+- ✅ Downloaded exchanges preview correctly in the integrated 3D viewer
+
+---
+
+**Migration Checklist:**
+- [x] Updated all package references to 7.5.0
+- [x] Removed `Client.GenerateViewableAsync` calls
+- [x] Replaced `RenderStyle`/`RGBA` with parameterized constructors
+- [x] Completed auth before launching the Connector UI
+- [ ] Tested create / update / download workflows end to end
+
+### 📚 Additional Resources
+
+- [APS DataExchange SDK Documentation](https://aps.autodesk.com/en/docs/dx-sdk/v1/developers_guide/overview/)
+- [APS DataExchange Release Notes](https://aps.autodesk.com/en/docs/dx-sdk/v1/developers_guide/release_notes/)
+- [Autodesk Platform Services Developer Portal](https://aps.autodesk.com/)
+- [DataExchange API Reference](https://aps.autodesk.com/en/docs/dx-sdk/v1/reference/)
+- [Sample Code Repository](https://github.com/autodesk-platform-services/aps-dataexchange-connector)
+
+---
+
+## 🔄 Migration Guide: SDK 7.2.1-beta Upgrade
 
 This section documents the migration from SDK 7.2.0 to **Autodesk Data Exchange SDK 7.2.1-beta**.
 

--- a/src/SampleConnector.csproj
+++ b/src/SampleConnector.csproj
@@ -59,7 +59,7 @@
   <!-- PackageReference - NuGet will automatically resolve all transitive dependencies -->
   <ItemGroup>
     <PackageReference Include="Autodesk.DataExchange" Version="7.5.0-beta" />
-    <PackageReference Include="Autodesk.DataExchange.UI" Version="7.5.0-alpha.3" />
+    <PackageReference Include="Autodesk.DataExchange.UI" Version="7.5.0-beta" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Settings.AppSettings" Version="2.2.2" />

--- a/test/SampleConnectorUnitTests/SampleConnectorUnitTests.csproj
+++ b/test/SampleConnectorUnitTests/SampleConnectorUnitTests.csproj
@@ -56,7 +56,7 @@
   <!-- PackageReference - NuGet will automatically resolve all transitive dependencies -->
   <ItemGroup>
     <PackageReference Include="Autodesk.DataExchange" Version="7.5.0-beta" />
-    <PackageReference Include="Autodesk.DataExchange.UI" Version="7.5.0-alpha.3" />
+    <PackageReference Include="Autodesk.DataExchange.UI" Version="7.5.0-beta" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">


### PR DESCRIPTION
Adds a SDK 7.5.0 upgrade section to the UI connector migration guide (previously stopped at 7.2.1-beta) and bumps Autodesk.DataExchange.UI from 7.5.0-alpha.3 → 7.5.0-beta in the src and test csproj files.

Migration guide documents the 7.2.1-beta → 7.5.0 breaking changes:
- Client.GenerateViewableAsync removed (viewable generation now server-side)
- RenderStyle / RGBA require parameterized constructors
- Auth completed + Client created off the UI thread before launching the bridge
- Simplified PackageReference format